### PR TITLE
A proposal for adding request_id to workers enqueued by workers.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+lib/simplekiq/config.rb @abernard @fzf

--- a/lib/simplekiq.rb
+++ b/lib/simplekiq.rb
@@ -17,7 +17,6 @@ module Simplekiq
   # Your code goes here...
   class << self
     def config
-      Datadog.config
       Config.config
     end
 

--- a/lib/simplekiq/config.rb
+++ b/lib/simplekiq/config.rb
@@ -2,15 +2,23 @@ module Simplekiq
   module Config
     class << self
       def config
+        Simplekiq::Datadog.config
         Sidekiq.configure_server do |config|
           config.on(:startup) do
             if Sidekiq.options[:queues] == ['default']
               Sidekiq.options = Sidekiq.options.merge(queues: QueueGetter.queues)
             end
           end
+          config.client_middleware do |chain|
+            chain.add(Simplekiq::MetadataClient)
+          end
+        end
+        Sidekiq.configure_server do |config|
+          config.server_middleware do |chain|
+            chain.add(Simplekiq::MetadataServer)
+          end
         end
       end
     end
   end
 end
-

--- a/lib/simplekiq/config.rb
+++ b/lib/simplekiq/config.rb
@@ -9,13 +9,17 @@ module Simplekiq
               Sidekiq.options = Sidekiq.options.merge(queues: QueueGetter.queues)
             end
           end
+          config.server_middleware do |chain|
+            chain.add(Simplekiq::MetadataServer)
+          end
           config.client_middleware do |chain|
             chain.add(Simplekiq::MetadataClient)
           end
         end
-        Sidekiq.configure_server do |config|
-          config.server_middleware do |chain|
-            chain.add(Simplekiq::MetadataServer)
+
+        Sidekiq.configure_client do |config|
+          config.client_middleware do |chain|
+            chain.add(Simplekiq::MetadataClient)
           end
         end
       end

--- a/lib/simplekiq/metadata_client.rb
+++ b/lib/simplekiq/metadata_client.rb
@@ -8,44 +8,26 @@ module Simplekiq
     include Simplekiq::Metadata
     include Simplekiq::MetadataRecorder
 
-    def config
-      Sidekiq.configure_client do |config|
-        config.client_middleware do |chain|
-          chain.add(Simplekiq::MetadataClient)
-        end
-      end
-    end
-
     def call(_worker, job, _queue, *)
-      begin
-        add_metadata(job)
-        yield
-      ensure
-        record(job)
-      end
-    end
-
-    def add_metadata(job)
-      job[METADATA_KEY] = client_metadata
+      job.merge!(client_metadata)
+      yield
+    ensure
+      record(job)
     end
 
     def client_metadata
       {
-        enqueued_at: enqueued_at,
-        enqueued_from: enqueued_from,
-        enqueued_from_host: enqueued_from_host,
-        request_id: request_id
+        'enqueued_from' => enqueued_from,
+        'enqueued_from_host' => enqueued_from_host,
+        'request_id' => request_id
       }
     end
 
     def request_id
       rid = Thread.current['atlas.request_id']
       return rid unless rid.nil?
-      Thread.current['core.request_id']
-    end
 
-    def enqueued_at
-      get_time
+      Thread.current['core.request_id']
     end
 
     def enqueued_from

--- a/lib/simplekiq/metadata_client.rb
+++ b/lib/simplekiq/metadata_client.rb
@@ -24,10 +24,7 @@ module Simplekiq
     end
 
     def request_id
-      rid = Thread.current['atlas.request_id']
-      return rid unless rid.nil?
-
-      Thread.current['core.request_id']
+      Thread.current['atlas.request_id'] || Thread.current['core.request_id']
     end
 
     def enqueued_from

--- a/lib/simplekiq/metadata_server.rb
+++ b/lib/simplekiq/metadata_server.rb
@@ -23,6 +23,7 @@ module Simplekiq
       begin_ref_micros = get_process_time_micros
       begin
         add_metadata_preexecute(job)
+        set_request_id(job)
         yield
       rescue StandardError => e
         add_metadata_error(job, e)
@@ -102,6 +103,12 @@ module Simplekiq
       return 0 if retries.nil? or retries.empty?
 
       job[METADATA_KEY]['retries'] + 1
+    end
+
+    def set_request_id(job)
+      if(job['request_id'])
+        Thread.current['atlas.request_id'] = job['request_id']
+      end
     end
   end
 end

--- a/spec/lib/simplekiq/metadata_client_spec.rb
+++ b/spec/lib/simplekiq/metadata_client_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe Simplekiq::MetadataClient do
     end
   end
 
+  after do
+    Thread.current['atlas.request_id'] = nil
+  end
+
   describe 'MetadataClient' do
     it 'includes the request id in metadata' do
       expect_any_instance_of(Simplekiq::MetadataClient).to receive(:record) do |_, job|

--- a/spec/lib/simplekiq/metadata_client_spec.rb
+++ b/spec/lib/simplekiq/metadata_client_spec.rb
@@ -11,9 +11,6 @@ RSpec.describe Simplekiq::MetadataClient do
   before do
     Thread.current['atlas.request_id'] = request_id
     Sidekiq::Testing.inline!
-    Sidekiq::Testing.server_middleware do |chain|
-      chain.add(Simplekiq::MetadataClient)
-    end
     allow(Socket).to receive(:gethostname).and_return(hostname)
     allow(Simplekiq).to receive(:app_name).and_return(app)
 
@@ -28,79 +25,23 @@ RSpec.describe Simplekiq::MetadataClient do
   describe 'MetadataClient' do
     it 'includes the request id in metadata' do
       expect_any_instance_of(Simplekiq::MetadataClient).to receive(:record) do |_, job|
-        expect(job[Simplekiq::Metadata::METADATA_KEY][:request_id]).to eq(request_id)
+        expect(job['request_id']).to eq(request_id)
       end
       HardWorker.perform_async({})
     end
 
     it 'includes the service enqueueing the job in the metadata' do
       expect_any_instance_of(Simplekiq::MetadataClient).to receive(:record) do |_, job|
-        expect(job[Simplekiq::Metadata::METADATA_KEY][:enqueued_from]).to eq(app)
+        expect(job['enqueued_from']).to eq(app)
       end
       HardWorker.perform_async({})
     end
 
     it 'includes the host enqueueing the job in the metadata' do
       expect_any_instance_of(Simplekiq::MetadataClient).to receive(:record) do |_, job|
-        expect(job[Simplekiq::Metadata::METADATA_KEY][:enqueued_from_host]).to eq(hostname)
+        expect(job['enqueued_from_host']).to eq(hostname)
       end
       HardWorker.perform_async({})
-    end
-
-    it 'includes the time enqueueing the job in the metadata' do
-      now = Time.now.utc.round(10).iso8601(3)
-      Timecop.freeze(now) do
-        expect_any_instance_of(Simplekiq::MetadataClient).to receive(:record) do |_, job|
-          expect(job[Simplekiq::Metadata::METADATA_KEY][:enqueued_at]).to eq(now)
-        end
-        HardWorker.perform_async({})
-      end
-    end
-
-    context 'Hardworker enqueues another worker' do
-      before do
-        class SubHardWorker
-          include Simplekiq::Worker
-
-          def perform(params)
-            puts params
-          end
-        end
-
-        class HardWorkerDos
-          include Simplekiq::Worker
-
-          def perform(_)
-            SubHardWorker.perform_async({})
-          end
-        end
-
-        class ThreadClearingMiddleware
-          def call(_worker, job, _queue, *)
-            Thread.current['atlas.request_id'] = nil
-            yield
-          end
-        end
-
-        Sidekiq::Testing.server_middleware do |chain|
-          chain.add(Simplekiq::MetadataClient)
-          chain.add(ThreadClearingMiddleware)
-        end
-      end
-
-      def assert_request_id(job)
-        expect(job[Simplekiq::Metadata::METADATA_KEY][:request_id]).to eq(request_id)
-      end
-
-      it 'includes request_id in the following workers metadata' do
-        allow_any_instance_of(Simplekiq::MetadataClient)
-          .to receive(:record).with(hash_including('class' => 'HardWorkerDos')) {|_, _, job| assert_request_id(job) }
-        allow_any_instance_of(Simplekiq::MetadataClient)
-          .to receive(:record).with(hash_including('class' => 'SubHardWorker')) {|_,_, job| assert_request_id(job) }
-        expect_any_instance_of(Simplekiq::MetadataClient).to receive(:record).twice
-
-        HardWorkerDos.perform_async({})
-      end
     end
   end
 end

--- a/spec/lib/simplekiq/metadata_client_spec.rb
+++ b/spec/lib/simplekiq/metadata_client_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Simplekiq::MetadataClient do
   let(:app) { 'APP' }
   let(:hostname) { 'HOSTNAME' }
   let(:request_id) { 123 }
-  let(:recorder) { Simplekiq::MetadataRecorder }
 
   before do
     Thread.current['atlas.request_id'] = request_id
@@ -28,33 +27,79 @@ RSpec.describe Simplekiq::MetadataClient do
 
   describe 'MetadataClient' do
     it 'includes the request id in metadata' do
-      allow(recorder).to receive(:record) do |job|
-        expect(job[Simplekiq::Metadata::METADATA_KEY]['request_id']).to eq(request_id)
+      expect_any_instance_of(Simplekiq::MetadataClient).to receive(:record) do |_, job|
+        expect(job[Simplekiq::Metadata::METADATA_KEY][:request_id]).to eq(request_id)
       end
       HardWorker.perform_async({})
     end
 
     it 'includes the service enqueueing the job in the metadata' do
-      allow(recorder).to receive(:record) do |job|
-        expect(job[Simplekiq::Metadata::METADATA_KEY]['enqueued_from']).to eq(app)
+      expect_any_instance_of(Simplekiq::MetadataClient).to receive(:record) do |_, job|
+        expect(job[Simplekiq::Metadata::METADATA_KEY][:enqueued_from]).to eq(app)
       end
       HardWorker.perform_async({})
     end
 
     it 'includes the host enqueueing the job in the metadata' do
-      allow(recorder).to receive(:record) do |job|
-        expect(job[Simplekiq::Metadata::METADATA_KEY]['enqueued_from_host']).to eq(hostname)
+      expect_any_instance_of(Simplekiq::MetadataClient).to receive(:record) do |_, job|
+        expect(job[Simplekiq::Metadata::METADATA_KEY][:enqueued_from_host]).to eq(hostname)
       end
       HardWorker.perform_async({})
     end
 
     it 'includes the time enqueueing the job in the metadata' do
-      now = Time.now
+      now = Time.now.utc.round(10).iso8601(3)
       Timecop.freeze(now) do
-        allow(recorder).to receive(:record) do |job|
-          expect(job[Simplekiq::Metadata::METADATA_KEY]['enqueued_at']).to eq(now)
+        expect_any_instance_of(Simplekiq::MetadataClient).to receive(:record) do |_, job|
+          expect(job[Simplekiq::Metadata::METADATA_KEY][:enqueued_at]).to eq(now)
         end
         HardWorker.perform_async({})
+      end
+    end
+
+    context 'Hardworker enqueues another worker' do
+      before do
+        class SubHardWorker
+          include Simplekiq::Worker
+
+          def perform(params)
+            puts params
+          end
+        end
+
+        class HardWorkerDos
+          include Simplekiq::Worker
+
+          def perform(_)
+            SubHardWorker.perform_async({})
+          end
+        end
+
+        class ThreadClearingMiddleware
+          def call(_worker, job, _queue, *)
+            Thread.current['atlas.request_id'] = nil
+            yield
+          end
+        end
+
+        Sidekiq::Testing.server_middleware do |chain|
+          chain.add(Simplekiq::MetadataClient)
+          chain.add(ThreadClearingMiddleware)
+        end
+      end
+
+      def assert_request_id(job)
+        expect(job[Simplekiq::Metadata::METADATA_KEY][:request_id]).to eq(request_id)
+      end
+
+      it 'includes request_id in the following workers metadata' do
+        allow_any_instance_of(Simplekiq::MetadataClient)
+          .to receive(:record).with(hash_including('class' => 'HardWorkerDos')) {|_, _, job| assert_request_id(job) }
+        allow_any_instance_of(Simplekiq::MetadataClient)
+          .to receive(:record).with(hash_including('class' => 'SubHardWorker')) {|_,_, job| assert_request_id(job) }
+        expect_any_instance_of(Simplekiq::MetadataClient).to receive(:record).twice
+
+        HardWorkerDos.perform_async({})
       end
     end
   end

--- a/spec/lib/simplekiq/metadata_client_spec.rb
+++ b/spec/lib/simplekiq/metadata_client_spec.rb
@@ -26,26 +26,24 @@ RSpec.describe Simplekiq::MetadataClient do
     Thread.current['atlas.request_id'] = nil
   end
 
-  describe 'MetadataClient' do
-    it 'includes the request id in metadata' do
-      expect_any_instance_of(Simplekiq::MetadataClient).to receive(:record) do |_, job|
-        expect(job['request_id']).to eq(request_id)
-      end
-      HardWorker.perform_async({})
+  it 'includes the request id in metadata' do
+    expect_any_instance_of(Simplekiq::MetadataClient).to receive(:record) do |_, job|
+      expect(job['request_id']).to eq(request_id)
     end
+    HardWorker.perform_async({})
+  end
 
-    it 'includes the service enqueueing the job in the metadata' do
-      expect_any_instance_of(Simplekiq::MetadataClient).to receive(:record) do |_, job|
-        expect(job['enqueued_from']).to eq(app)
-      end
-      HardWorker.perform_async({})
+  it 'includes the service enqueueing the job in the metadata' do
+    expect_any_instance_of(Simplekiq::MetadataClient).to receive(:record) do |_, job|
+      expect(job['enqueued_from']).to eq(app)
     end
+    HardWorker.perform_async({})
+  end
 
-    it 'includes the host enqueueing the job in the metadata' do
-      expect_any_instance_of(Simplekiq::MetadataClient).to receive(:record) do |_, job|
-        expect(job['enqueued_from_host']).to eq(hostname)
-      end
-      HardWorker.perform_async({})
+  it 'includes the host enqueueing the job in the metadata' do
+    expect_any_instance_of(Simplekiq::MetadataClient).to receive(:record) do |_, job|
+      expect(job['enqueued_from_host']).to eq(hostname)
     end
+    HardWorker.perform_async({})
   end
 end

--- a/spec/lib/simplekiq/metadata_server_spec.rb
+++ b/spec/lib/simplekiq/metadata_server_spec.rb
@@ -1,49 +1,53 @@
 require 'spec_helper'
 require 'simplekiq/testing'
-require 'timecop'
+
+class HardWorker
+  include Simplekiq::Worker
+
+  def perform(_)
+  end
+end
 
 RSpec.describe Simplekiq::MetadataServer do
   let(:app) { 'APP' }
   let(:hostname) { 'HOSTNAME' }
   let(:request_id) { 123 }
   let(:recorder) { Simplekiq::MetadataRecorder }
+  let(:now) { Simplekiq::MetadataServer.new.get_time }
 
   before do
-    Thread.current['atlas.request_id'] = request_id
+    Timecop.freeze
     Sidekiq::Testing.inline!
     Sidekiq::Testing.server_middleware do |chain|
       chain.add(Simplekiq::MetadataServer)
     end
-    class HardWorker
-      include Simplekiq::Worker
+  end
 
-      def perform(_)
-      end
-    end
+  after do
+    Timecop.return
   end
 
   describe 'MetadataServer' do
     it 'includes the time the job started to process in the metadata' do
-      Timecop.freeze do
-        now = Simplekiq::MetadataServer.new.get_time
-        expect_any_instance_of(Simplekiq::MetadataServer).to receive(:record) do |_, job|
-          expect(job['processed_at']).to eq(now)
-        end
-        HardWorker.perform_async({})
-      end
+      expect_any_instance_of(Simplekiq::MetadataServer).to receive(:record).with(
+        hash_including(
+          'first_processed_at' => now,
+          'processed_at' => now,
+          'processed_by' => Simplekiq.app_name,
+          'processed_by_host' => Socket.gethostname
+        )
+      )
+
+      HardWorker.perform_async({})
     end
 
-    context 'Hardworker enqueues another worker' do
+    context 'with request_id' do
       before do
-        Sidekiq::Testing.server_middleware do |chain|
-          chain.add(Simplekiq::MetadataServer)
-        end
+        allow_any_instance_of(Simplekiq::MetadataClient).to receive(:request_id).and_return(request_id)
       end
 
       it 'includes request_id in the following workers metadata' do
-        allow_any_instance_of(Simplekiq::MetadataServer)
-          .to receive(:add_request_id_to_thread).and_call_original
-        HardWorker.perform_async({})
+        expect{ HardWorker.perform_async({}) }.to change{ Thread.current['atlas.request_id'] }.from(nil).to(request_id)
       end
     end
   end

--- a/spec/lib/simplekiq/metadata_server_spec.rb
+++ b/spec/lib/simplekiq/metadata_server_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Simplekiq::MetadataServer do
 
   after do
     Timecop.return
+    Thread.current['atlas.request_id'] = nil
   end
 
   describe 'MetadataServer' do
@@ -44,6 +45,7 @@ RSpec.describe Simplekiq::MetadataServer do
     context 'with request_id' do
       before do
         allow_any_instance_of(Simplekiq::MetadataClient).to receive(:request_id).and_return(request_id)
+        Thread.current['atlas.request_id'] = nil
       end
 
       it 'includes request_id in the following workers metadata' do

--- a/spec/lib/simplekiq/metadata_server_spec.rb
+++ b/spec/lib/simplekiq/metadata_server_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'simplekiq/testing'
+require 'timecop'
 
 RSpec.describe Simplekiq::MetadataServer do
   let(:app) { 'APP' }
@@ -11,7 +12,6 @@ RSpec.describe Simplekiq::MetadataServer do
     Thread.current['atlas.request_id'] = request_id
     Sidekiq::Testing.inline!
     Sidekiq::Testing.server_middleware do |chain|
-      chain.add(Simplekiq::MetadataClient)
       chain.add(Simplekiq::MetadataServer)
     end
     class HardWorker
@@ -24,11 +24,25 @@ RSpec.describe Simplekiq::MetadataServer do
 
   describe 'MetadataServer' do
     it 'includes the time the job started to process in the metadata' do
-      now = Time.now
-      Timecop.freeze(now) do
-        allow(recorder).to receive(:record) do |job|
-          expect(job[Simplekiq::Metadata::METADATA_KEY]['processed_at']).to eq(now)
+      Timecop.freeze do
+        now = Simplekiq::MetadataServer.new.get_time
+        expect_any_instance_of(Simplekiq::MetadataServer).to receive(:record) do |_, job|
+          expect(job['processed_at']).to eq(now)
         end
+        HardWorker.perform_async({})
+      end
+    end
+
+    context 'Hardworker enqueues another worker' do
+      before do
+        Sidekiq::Testing.server_middleware do |chain|
+          chain.add(Simplekiq::MetadataServer)
+        end
+      end
+
+      it 'includes request_id in the following workers metadata' do
+        allow_any_instance_of(Simplekiq::MetadataServer)
+          .to receive(:add_request_id_to_thread).and_call_original
         HardWorker.perform_async({})
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'bundler/setup'
 require 'pry'
 require 'sidekiq/testing'
 require 'simplekiq'
+require 'timecop'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Add request_id back to the tread when starting up a job queued from another job

Note: I cant actually get this test to pass properly, so some advice would be great. The idea initially was to use middleware to clear the request_id from the Thread.current. I dont think thats really working, and I've also somehow managed, via weird mocking, to stop it from even getting the request_id. 

Maybe another option here would be just to clear the request_id in the perform method of the original worker. 

A word about testing middleware with sidekiq: 
"By default, the test harness (in either mode) does not run any server side middleware" - https://github.com/mperham/sidekiq/wiki/Testing#testing-server-middleware 