### PR TITLE
Fix concatenation for tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Simplekiq Gem Changes
 
-### 4.0.1
+### 4.0.2
 
 - Add DD metric to keep track of worker group(ie: threaded, low_priority, common/undefined)
+- Remove v4.0.1 because of metric got concatenated incorrectly
 
 ### 3.2.7
 

--- a/lib/simplekiq/datadog.rb
+++ b/lib/simplekiq/datadog.rb
@@ -11,9 +11,10 @@ module Simplekiq
             chain.add(
               Sidekiq::Middleware::Server::Datadog,
               tags: [
+                ->(_worker, _job, _queue, _error) { "service:#{app_name}" },
                 lambda do |_worker, _job, _queue, _error|
                   worker_group = ENV.fetch('DATADOG_SIDEKIQ_WORKER_GROUP', 'undefined')
-                  "service:#{app_name},worker_group:#{worker_group}"
+                  "worker_group:#{worker_group}"
                 end
               ]
             )

--- a/lib/simplekiq/version.rb
+++ b/lib/simplekiq/version.rb
@@ -1,3 +1,3 @@
 module Simplekiq
-  VERSION = '4.0.1'.freeze
+  VERSION = '4.0.2'.freeze
 end

--- a/spec/lib/simplekiq/datadog_spec.rb
+++ b/spec/lib/simplekiq/datadog_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 
 RSpec.describe Simplekiq::Datadog do
   context 'tags' do
+    subject(:tag) do
+      datadog_args[:tags][tag_number].call(nil, nil, nil, nil)
+    end
+    let(:tag_number) { 0 }
     let(:datadog_middleware) do
       Sidekiq.server_middleware.entries.detect do |entry|
         entry.klass == Sidekiq::Middleware::Server::Datadog
@@ -11,29 +15,39 @@ RSpec.describe Simplekiq::Datadog do
     let(:datadog_args) do
       datadog_middleware.instance_variable_get(:@args).first
     end
+    context 'when checking first tag' do
+      it { expect(subject).to eq('service:undefined') }
 
-    subject(:tag) do
-      datadog_args[:tags].first.call(nil, nil, nil, nil)
+      context 'when Rails application' do
+        let(:rails) { class_double('Rails') }
+        before do
+          stub_const('Rails', rails)
+          stub_const('Rails::VERSION::MAJOR', 6)
+          allow(rails).to receive_message_chain(
+            'application.class.module_parent_name.underscore'
+          ).and_return('app_name')
+        end
+
+        it { expect(subject).to eq('service:app_name') }
+      end
     end
+    context 'when checking second tag' do
+      let(:tag_number) { 1 }
 
-    it { expect(subject).to eq('service:undefined,worker_group:undefined') }
-
-    context 'when Rails application' do
-      let(:rails) { class_double('Rails') }
-      before do
-        stub_const('Rails', rails)
-        stub_const('Rails::VERSION::MAJOR', 6)
-        allow(rails).to receive_message_chain(
-          'application.class.module_parent_name.underscore'
-        ).and_return('app_name')
-        stub_const(
-          'ENV',
-          ENV.to_hash.merge('DATADOG_SIDEKIQ_WORKER_GROUP' => 'custom_worker_group')
-        )
+      context 'when DATADOG_SIDEKIQ_WORKER_GROUP env variable not set' do
+        it { expect(subject).to eq('worker_group:undefined') }
       end
 
-      it do
-        expect(subject).to eq('service:app_name,worker_group:custom_worker_group')
+      context 'when DATADOG_SIDEKIQ_WORKER_GROUP env variable set' do
+        before do
+          stub_const(
+            'ENV',
+            ENV.to_hash.merge(
+              'DATADOG_SIDEKIQ_WORKER_GROUP' => 'custom_worker_group'
+            )
+          )
+        end
+        it { expect(subject).to eq('worker_group:custom_worker_group') }
       end
     end
   end

--- a/spec/lib/simplekiq/datadog_spec.rb
+++ b/spec/lib/simplekiq/datadog_spec.rb
@@ -2,9 +2,8 @@ require 'spec_helper'
 
 RSpec.describe Simplekiq::Datadog do
   context 'tags' do
-    subject(:tag) do
-      datadog_args[:tags][tag_number].call(nil, nil, nil, nil)
-    end
+    subject(:tag) { datadog_args[:tags][tag_number].call(nil, nil, nil, nil) }
+
     let(:tag_number) { 0 }
     let(:datadog_middleware) do
       Sidekiq.server_middleware.entries.detect do |entry|
@@ -16,7 +15,7 @@ RSpec.describe Simplekiq::Datadog do
       datadog_middleware.instance_variable_get(:@args).first
     end
     context 'when checking first tag' do
-      it { expect(subject).to eq('service:undefined') }
+      it { is_expected.to eq('service:undefined') }
 
       context 'when Rails application' do
         let(:rails) { class_double('Rails') }
@@ -28,14 +27,14 @@ RSpec.describe Simplekiq::Datadog do
           ).and_return('app_name')
         end
 
-        it { expect(subject).to eq('service:app_name') }
+        it { is_expected.to eq('service:app_name') }
       end
     end
     context 'when checking second tag' do
       let(:tag_number) { 1 }
 
       context 'when DATADOG_SIDEKIQ_WORKER_GROUP env variable not set' do
-        it { expect(subject).to eq('worker_group:undefined') }
+        it { is_expected.to eq('worker_group:undefined') }
       end
 
       context 'when DATADOG_SIDEKIQ_WORKER_GROUP env variable set' do
@@ -47,7 +46,7 @@ RSpec.describe Simplekiq::Datadog do
             )
           )
         end
-        it { expect(subject).to eq('worker_group:custom_worker_group') }
+        it { is_expected.to eq('worker_group:custom_worker_group') }
       end
     end
   end


### PR DESCRIPTION
Fix for #41.

Concatenation for how tags get added was incorrect. The middleware added the tags like this
``` ruby
service:processorworker_group:low_priority_worker
service:processorworker_group:threaded_worker
service:processorworker_group:undefined
```

Simplekiq uses the midleware dadadog client and it has not been passed to statsD yet so we still have access to the arrays.
Source for how the tags get built https://github.com/bsm/sidekiq-datadog/blob/master/lib/sidekiq/middleware/server/datadog.rb#L71
