### PR TITLE
Add custom redis enqueuing command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Simplekiq Gem Changes
 
+### 4.1.0
+
+- Add queue routing via environment variables using enqueue_with_routing
+
 ### 4.0.2
 
 - Add DD metric to keep track of worker group(ie: threaded, low_priority, common/undefined)

--- a/lib/simplekiq.rb
+++ b/lib/simplekiq.rb
@@ -33,7 +33,7 @@ module Simplekiq
       end
     end
 
-    def enqueue(kwargs)
+    def enqueue_with_routing(kwargs)
       Simplekiq::EnqueueRouter.instance.enqueue(kwargs)
     end
   end

--- a/lib/simplekiq.rb
+++ b/lib/simplekiq.rb
@@ -3,6 +3,7 @@ require 'core_extensions/hash'
 require 'sidekiq/cli'
 require 'simplekiq/config'
 require 'simplekiq/datadog'
+require 'simplekiq/enqueue_router'
 require 'simplekiq/job_retry'
 require 'simplekiq/metadata_client'
 require 'simplekiq/metadata_server'
@@ -30,6 +31,10 @@ module Simplekiq
       else
         ::Rails.application.class.parent_name.underscore
       end
+    end
+
+    def enqueue(kwargs)
+      Simplekiq::EnqueueRouter.instance.enqueue(kwargs)
     end
   end
 end

--- a/lib/simplekiq/enqueue_router.rb
+++ b/lib/simplekiq/enqueue_router.rb
@@ -50,13 +50,13 @@ module Simplekiq
       end
     end
 
+    private
+
     def read_instances_from_environment
       matching_envs.each do |service_name, url|
         add_pool(service_name, url)
       end
     end
-
-    private
 
     def initialize
       super()

--- a/lib/simplekiq/enqueue_router.rb
+++ b/lib/simplekiq/enqueue_router.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Simplekiq
+  # Class to help route sidekiq jobs to the appropriate sidekiq instance if environment variables
+  # exist following the convention SIDEKIQ_<service name>_REDIS_URL
+  class EnqueueRouter
+    include Singleton
+
+    # Enqueue a Sidekiq job into redis, to be picked up by a worker in another app
+    def enqueue(queue_name:, class_name:, params:, timestamp: nil)
+      push_params = {
+        queue: queue_name,
+        class: class_name,
+        args: [params] # args must be an array
+      }
+      push_params[:at] = timestamp.to_f if timestamp.present?
+
+      service = queue_name.split('-').first
+      alt_redis = redis_for_service(service)
+
+      if defined?(::Chime::Dog)
+        Chime::Dog.increment('sidekiq.remote_enqueue', tags: { destination: service })
+      end
+
+      Sidekiq::Client.via(alt_redis) { Sidekiq::Client.push(push_params.stringify_keys) }
+    end
+
+    def redis_for_service(service)
+      @sidekiq_instances[service] || Sidekiq.redis_pool
+    end
+
+    def add_pool(service, url)
+      if defined?(::Rails)
+        Rails.logger.info { "Adding Sidekiq Redis pool for #{service} at #{url}" }
+      end
+      @sidekiq_instances[service] = ConnectionPool.new { Redis.new(url: url) }
+    end
+
+    def reset!
+      @sidekiq_instances = {}
+      read_instances_from_environment
+    end
+
+    def matching_envs
+      ENV.each_with_object({}) do |(key, url), hash|
+        key.match(/^SIDEKIQ_(.+)_REDIS_URL$/) do |match|
+          service_name = match[1].downcase
+          hash[service_name] = url
+        end
+      end
+    end
+
+    def read_instances_from_environment
+      matching_envs.each do |service_name, url|
+        add_pool(service_name, url)
+      end
+    end
+
+    private
+
+    def initialize
+      super()
+      reset!
+    end
+  end
+end

--- a/lib/simplekiq/version.rb
+++ b/lib/simplekiq/version.rb
@@ -1,3 +1,3 @@
 module Simplekiq
-  VERSION = '4.0.2'.freeze
+  VERSION = '4.1.0'.freeze
 end

--- a/simplekiq.gemspec
+++ b/simplekiq.gemspec
@@ -30,8 +30,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sidekiq-datadog', '~> 0.4'
 
   spec.add_development_dependency 'bundler', '~> 2.1.0'
+  spec.add_development_dependency 'climate_control'
   spec.add_development_dependency 'fakeredis', '~> 0.7.0'
-  spec.add_development_dependency 'pry-byebug', '3.7.0'
+  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'timecop', '>= 0.9.1'

--- a/spec/lib/simplekiq/enqueue_router_spec.rb
+++ b/spec/lib/simplekiq/enqueue_router_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require 'simplekiq/enqueue_router'
+
+RSpec.describe Simplekiq::EnqueueRouter do
+  let(:class_name) { 'ClassyClassWorker' }
+  let(:queue_name) { "#{service_name}-classy_class" }
+  let(:service_name) { 'something' }
+  let(:timestamp) { nil }
+  let(:args) do
+    [
+      {
+        key_1: 'val_1',
+        key_2: 'val_2'
+      }
+    ]
+  end
+  let(:second_redis_url) { 'redis://fancy.redis.biz' }
+  let(:instance) { described_class.instance }
+
+  before do
+    instance.reset!
+  end
+
+  describe '#enqueue' do
+    subject(:enqueue) { instance.enqueue(params) }
+
+    let(:params) do
+      {
+        class_name: class_name,
+        queue_name: queue_name,
+        params: args,
+      }
+    end
+
+    before do
+      allow(Sidekiq::Client).to receive(:via).and_call_original
+      allow(Sidekiq::Client).to receive(:push)
+    end
+
+    it 'calls through redis_pool' do
+      enqueue
+      expect(Sidekiq::Client).to have_received(:via).with(Sidekiq.redis_pool)
+    end
+
+    it 'calls Sidekiq::Client.push with basic args' do
+      enqueue
+      expect(Sidekiq::Client).to have_received(:push).with(
+        'queue' => queue_name,
+        'class' => class_name,
+        'args' => [args]
+      )
+    end
+
+    context 'when queue has routing' do
+      around do |example|
+        ClimateControl.modify(SIDEKIQ_SOMETHING_REDIS_URL: second_redis_url) do
+          example.run
+        end
+      end
+
+      it 'calls through custom redis url' do
+        enqueue
+        expect(Sidekiq::Client).to have_received(:via)
+        expect(Sidekiq::Client).not_to have_received(:via).with(Sidekiq.redis_pool)
+      end
+
+      it 'calls Sidekiq::Client.push with basic args' do
+        enqueue
+        expect(Sidekiq::Client).to have_received(:push).with(
+          'queue' => queue_name,
+          'class' => class_name,
+          'args' => [args]
+        )
+      end
+    end
+
+    context 'when Chime::Dog is defined' do
+      let(:chime_dog) { double('Chime::Dog', increment: nil) }
+
+      before do
+        stub_const('::Chime::Dog', chime_dog)
+      end
+
+      it 'tells DataDog what it did' do
+        enqueue
+        expect(chime_dog)
+          .to have_received(:increment)
+          .with('sidekiq.remote_enqueue', tags: { destination: service_name })
+      end
+    end
+
+    context 'when a timestamp is provided' do
+      let(:timestamp) { Time.now.next_day(10).to_time }
+      let(:params) { super().merge(timestamp: timestamp) }
+
+      it 'adds the timestamp to the args' do
+        expect(Sidekiq::Client).to receive(:push).with(
+          'queue' => queue_name,
+          'class' => class_name,
+          'args' => [args],
+          'at' => timestamp.to_f
+        )
+
+        enqueue
+      end
+    end
+  end
+
+  describe '.redis_for_service' do
+    subject { instance.redis_for_service(service_name) }
+
+    context 'without alternate URL' do
+      it 'returns Sidekiq.redis_pool by default' do
+        is_expected.to be(Sidekiq.redis_pool)
+      end
+    end
+
+    context 'with alternate URL' do
+      before { instance.add_pool(service_name, second_redis_url) }
+
+      it 'generates a distinct pool' do
+        is_expected.not_to be(Sidekiq.redis_pool)
+      end
+
+      it 'retains the original for other services' do
+        expect(instance.redis_for_service('consumer')).to be(Sidekiq.redis_pool)
+      end
+    end
+  end
+
+  describe '.matching_envs' do
+    subject(:matching_envs) { instance.matching_envs }
+
+    around do |example|
+      ClimateControl.modify(FOO: 'bar', SIDEKIQ_FUNKY_REDIS_URL: second_redis_url) do
+        example.run
+      end
+    end
+
+    it 'includes the funky redis URL' do
+      is_expected.to include('funky' => second_redis_url)
+    end
+
+    it 'only yields once' do
+      expect(matching_envs.size).to eq(1)
+    end
+  end
+end

--- a/spec/simplekiq_spec.rb
+++ b/spec/simplekiq_spec.rb
@@ -43,13 +43,13 @@ RSpec.describe Simplekiq do
     end
   end
 
-  describe '#enqueue' do
-    subject { described_class.enqueue(params) }
+  describe '#enqueue_with_routing' do
+    subject { described_class.enqueue_with_routing(params) }
 
     let(:params) { { queue_name: 'magic-super-queue', class_name: 'MyClassName', params: {} } }
 
     it 'calls ' do
-      expect(Simplekiq::EnqueueRouter.instance).to receive(:enqueue).with(params).once
+      expect(Simplekiq::EnqueueRouter.instance).to receive(:enqueue_with_routing).with(params).once
 
       subject
     end

--- a/spec/simplekiq_spec.rb
+++ b/spec/simplekiq_spec.rb
@@ -1,4 +1,3 @@
-require 'pry'
 RSpec.describe Simplekiq do
   it "has a version number" do
     expect(Simplekiq::VERSION).not_to be nil
@@ -41,6 +40,18 @@ RSpec.describe Simplekiq do
           expect(described_class.app_name).to eq('app_name')
         end
       end
+    end
+  end
+
+  describe '#enqueue' do
+    subject { described_class.enqueue(params) }
+
+    let(:params) { { queue_name: 'magic-super-queue', class_name: 'MyClassName', params: {} } }
+
+    it 'calls ' do
+      expect(Simplekiq::EnqueueRouter.instance).to receive(:enqueue).with(params).once
+
+      subject
     end
   end
 end

--- a/spec/simplekiq_spec.rb
+++ b/spec/simplekiq_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Simplekiq do
     let(:params) { { queue_name: 'magic-super-queue', class_name: 'MyClassName', params: {} } }
 
     it 'calls ' do
-      expect(Simplekiq::EnqueueRouter.instance).to receive(:enqueue_with_routing).with(params).once
+      expect(Simplekiq::EnqueueRouter.instance).to receive(:enqueue).with(params).once
 
       subject
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,10 @@
 require 'bundler/setup'
+require 'climate_control'
+require 'fakeredis'
 require 'pry'
 require 'sidekiq/testing'
 require 'simplekiq'
 require 'timecop'
-require 'fakeredis'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
This moves SidekiqEnqueue functionality to a more available place. I gated some of the datadog stuff behind a check for defintion of constants.

This enables service level database routing based on the queue name. And pool discovery based on environment variables.